### PR TITLE
Xcode 10.2 compatibility: don't hard-code ARCHS

### DIFF
--- a/build_configs/CardIO_Framework.xcconfig
+++ b/build_configs/CardIO_Framework.xcconfig
@@ -4,7 +4,6 @@
 //
 //
 
-//ARCHS = arm64 armv7 armv7s
 ONLY_ACTIVE_ARCH = NO
 
 GCC_VERSION = com.apple.compilers.llvm.clang.1_0

--- a/build_configs/CardIO_Framework.xcconfig
+++ b/build_configs/CardIO_Framework.xcconfig
@@ -4,7 +4,7 @@
 //
 //
 
-ARCHS = arm64 armv7 armv7s
+//ARCHS = arm64 armv7 armv7s
 ONLY_ACTIVE_ARCH = NO
 
 GCC_VERSION = com.apple.compilers.llvm.clang.1_0


### PR DESCRIPTION
Carthage won’t build this without this change, due to some kind of assert in `dsymutil`.

Failure looks like this…
```
*** Building scheme "CardIO" in icc.xcodeproj
Build Failed
	Task failed with exit code 1:
	/usr/bin/xcrun dsymutil /[snip]/Carthage/Build/iOS/CardIO.framework/CardIO -o /[snip]/Carthage/Build/iOS/CardIO.framework.dSYM

This usually indicates that project itself failed to compile. Please check the xcodebuild log for more details: [snip]
```